### PR TITLE
Save Stores On Local Machine

### DIFF
--- a/bcli/scripts/script.py
+++ b/bcli/scripts/script.py
@@ -27,12 +27,14 @@ def store_add():
         {'type': 'input', 'name': 'store_hash', 'message': f'Store hash: '},
         {'type': 'input', 'name': 'access_token', 'message': f'Access token: '},
     ])
-    # TODO: Confirm overwrite?
-    # TODO: Confirm user input is valid before saving
 
-    write_to_app_dir('stores.json',
-                     key=user_input['store_name'],
-                     value={'store_hash': user_input['store_hash'], 'access_token': user_input['access_token']})
+    if read_from_app_dir('stores.json').get(user_input['store_name']):
+        user_input['confirm'] = prompt([{'type': 'confirm', 'name': 'confirm', 'message': f'Overwrite? '}])['confirm']
+
+    if user_input.get('confirm', True):
+        write_to_app_dir('stores.json',
+                         key=user_input['store_name'],
+                         value={'store_hash': user_input['store_hash'], 'access_token': user_input['access_token']})
 
 
 @store.command('list')
@@ -60,10 +62,8 @@ def store_list():
 @click.argument('store_name')
 def store_delete(store_name):
     """  """
-    # TODO: Delete confirmation
-    # TODO: Decide if I want to check if a store exists before run .pop on it
-
     delete_from_app_dir('stores.json', key=store_name)
+    echo(f'Deleted store ({store_name}).')
 
 
 # Product Commands -----------------------------------------------------------------------------------------------------

--- a/bcli/scripts/script.py
+++ b/bcli/scripts/script.py
@@ -1,13 +1,13 @@
+import json
 import webbrowser
+from pathlib import Path
 
 import click
 from PyInquirer import prompt
 from click import echo
+from prettytable import PrettyTable
 
-from ..utils import bigcommerce, pretty_table
-
-store_db = {
-}
+from ..utils import bigcommerce, pretty_table, get_store_creds
 
 
 @click.group()
@@ -15,6 +15,88 @@ def cli():
     pass
 
 
+# Store Commands -------------------------------------------------------------------------------------------------------
+@cli.group()
+def store():
+    pass
+
+
+@store.command('add')
+def store_add():
+    """  """
+    user_input = prompt([
+        {'type': 'input', 'name': 'store', 'message': f'Store name: '},
+        {'type': 'input', 'name': 'hash', 'message': f'Store hash: '},
+        {'type': 'input', 'name': 'access_token', 'message': f'Access token: '},
+    ])
+
+    # TODO: Confirm overwrite?
+    # TODO: Confirm user input is valid before saving
+
+    app_dir = click.get_app_dir('bcli')
+    if not Path(app_dir).is_dir():
+        Path(app_dir).mkdir(parents=True, exist_ok=True)
+
+    config_path = f'{app_dir}/stores.json'
+    if not Path(config_path).is_file():
+        with open(config_path, 'w') as stores_file:
+            stores = {}
+            stores[user_input['store']] = {'store_hash': user_input['hash'], 'access_token': user_input['access_token']}
+            json.dump(stores, stores_file)
+    else:
+        with open(config_path, 'r') as stores_file:
+            stores = json.load(stores_file)
+            stores[user_input['store']] = {'store_hash': user_input['hash'], 'access_token': user_input['access_token']}
+        with open(config_path, 'w') as stores_file:
+            json.dump(stores, stores_file)
+
+
+@store.command('list')
+def store_list():
+    """  """
+    app_dir = click.get_app_dir('bcli')
+    config_path = f'{app_dir}/stores.json'
+    if not Path(config_path).is_file():
+        stores = {}
+    else:
+        with open(config_path, 'r') as stores_file:
+            stores = json.load(stores_file)
+
+    table = PrettyTable()
+    table.field_names = ['Store', 'Store Hash', 'Access Token']
+    table.align['Store'] = "l"
+    table.align['Store Hash'] = "l"
+    table.align['Access Token'] = "l"
+
+    for store_name, store_creds in stores.items():
+        table.add_row([
+            store_name,
+            store_creds['store_hash'],
+            store_creds['access_token']
+        ])
+
+    echo(table)
+
+
+@store.command('delete')
+@click.argument('store')
+def store_delete(store):
+    """  """
+    app_dir = click.get_app_dir('bcli')
+    config_path = f'{app_dir}/stores.json'
+
+    # TODO: Delete confirmation
+    # TODO: Decide if I want to check if a store exists before run .pop on it
+
+    if Path(config_path).is_file():
+        with open(config_path, 'r') as stores_file:
+            stores = json.load(stores_file)
+            stores.pop(store)
+        with open(config_path, 'w') as stores_file:
+            json.dump(stores, stores_file)
+
+
+# Product Commands -----------------------------------------------------------------------------------------------------
 @cli.group()
 def product():
     pass
@@ -24,8 +106,9 @@ def product():
 @click.option('-s', '--store', required=True)
 @click.option('--filter_name', default=None)
 def product_list(store, filter_name):
-    catalog_products = bigcommerce.CatalogProduct.get(store_hash=store_db[store]['store_hash'],
-                                                      access_token=store_db[store]['access_token'],
+    store = get_store_creds(store)
+    catalog_products = bigcommerce.CatalogProduct.get(store_hash=store['store_hash'],
+                                                      access_token=store['access_token'],
                                                       params={'limit': 250, 'include': 'variants'})
     if filter_name:
         catalog_products = [p for p in catalog_products
@@ -39,17 +122,18 @@ def product_list(store, filter_name):
 @click.option('-s', '--store', required=True)
 @click.option('-w', '--web', is_flag=True)
 def product_view(product_id, store, web):
-    catalog_product = bigcommerce.CatalogProduct.get(store_hash=store_db[store]['store_hash'],
-                                                     access_token=store_db[store]['access_token'],
+    store = get_store_creds(store)
+    catalog_product = bigcommerce.CatalogProduct.get(store_hash=store['store_hash'],
+                                                     access_token=store['access_token'],
                                                      resource_id=product_id,
                                                      params={'include': 'variants'})
 
-    catalog_product_variants = bigcommerce.CatalogProductVariant.get(store_hash=store_db[store]['store_hash'],
-                                                                     access_token=store_db[store]['access_token'],
+    catalog_product_variants = bigcommerce.CatalogProductVariant.get(store_hash=store['store_hash'],
+                                                                     access_token=store['access_token'],
                                                                      resource_id=product_id)
     if web:
         webbrowser.open(
-            f'https://store-{store_db[store]["store_hash"]}.mybigcommerce.com/manage/products/edit/{product_id}')
+            f'https://store-{store["store_hash"]}.mybigcommerce.com/manage/products/edit/{product_id}')
     else:
         echo(pretty_table.CatalogProduct.build_table([catalog_product]))
         if len(catalog_product_variants) > 1:
@@ -60,8 +144,9 @@ def product_view(product_id, store, web):
 @click.argument('product_id')
 @click.option('-s', '--store', required=True)
 def product_edit(product_id, store):
-    catalog_product = bigcommerce.CatalogProduct.get(store_hash=store_db[store]['store_hash'],
-                                                     access_token=store_db[store]['access_token'],
+    store = get_store_creds(store)
+    catalog_product = bigcommerce.CatalogProduct.get(store_hash=store['store_hash'],
+                                                     access_token=store['access_token'],
                                                      resource_id=product_id,
                                                      params={'include': 'variants'})
 
@@ -87,8 +172,8 @@ def product_edit(product_id, store):
     ])
 
     if user_input['confirm']:
-        bigcommerce.CatalogProduct.put(store_hash=store_db[store]['store_hash'],
-                                       access_token=store_db[store]['access_token'],
+        bigcommerce.CatalogProduct.put(store_hash=store['store_hash'],
+                                       access_token=store['access_token'],
                                        resource_id=product_id,
                                        json={user_input['field']: user_input['value']})
         echo('Edit complete.')

--- a/bcli/scripts/script.py
+++ b/bcli/scripts/script.py
@@ -21,7 +21,7 @@ def store():
 
 @store.command('add')
 def store_add():
-    """  """
+    """ Save store API credentials. """
     user_input = prompt([
         {'type': 'input', 'name': 'store_name', 'message': f'Store name: '},
         {'type': 'input', 'name': 'store_hash', 'message': f'Store hash: '},
@@ -39,7 +39,7 @@ def store_add():
 
 @store.command('list')
 def store_list():
-    """  """
+    """ Print all saved API credentials. """
     stores = read_from_app_dir('stores.json')
 
     table = PrettyTable()
@@ -61,7 +61,7 @@ def store_list():
 @store.command('delete')
 @click.argument('store_name')
 def store_delete(store_name):
-    """  """
+    """ Delete a set of API credentials by store name. """
     delete_from_app_dir('stores.json', key=store_name)
     echo(f'Deleted store ({store_name}).')
 

--- a/bcli/scripts/script.py
+++ b/bcli/scripts/script.py
@@ -143,7 +143,8 @@ def product_view(product_id, store, web):
 @product.command('edit')
 @click.argument('product_id')
 @click.option('-s', '--store', required=True)
-def product_edit(product_id, store):
+@click.option('--field', default=None)
+def product_edit(product_id, store, field):
     store = get_store_creds(store)
     catalog_product = bigcommerce.CatalogProduct.get(store_hash=store['store_hash'],
                                                      access_token=store['access_token'],
@@ -152,17 +153,23 @@ def product_edit(product_id, store):
 
     echo(pretty_table.CatalogProduct.build_table([catalog_product]))
 
+    if not field:
+        user_input = prompt([
+            {
+                'type': 'list',
+                'name': 'field',
+                'message': 'What field would you like to edit?',
+                'choices': list(catalog_product.keys())
+            },
+        ])
+        field = user_input['field']
+
     user_input = prompt([
-        {
-            'type': 'list',
-            'name': 'field',
-            'message': 'What field would you like to edit?',
-            'choices': list(catalog_product.keys())
-        },
         {
             'type': 'input',
             'name': 'value',
-            'message': f'New value: '
+            'message': f'New value: ',
+            'default': catalog_product[field]
         },
         {
             'type': 'confirm',
@@ -175,7 +182,7 @@ def product_edit(product_id, store):
         bigcommerce.CatalogProduct.put(store_hash=store['store_hash'],
                                        access_token=store['access_token'],
                                        resource_id=product_id,
-                                       json={user_input['field']: user_input['value']})
+                                       json={field: user_input['value']})
         echo('Edit complete.')
     else:
         echo('Edit canceled.')

--- a/bcli/utils/__init__.py
+++ b/bcli/utils/__init__.py
@@ -1,1 +1,1 @@
-from .utils import get_store_creds
+from .utils import read_from_app_dir, write_to_app_dir, delete_from_app_dir

--- a/bcli/utils/__init__.py
+++ b/bcli/utils/__init__.py
@@ -1,0 +1,1 @@
+from .utils import get_store_creds

--- a/bcli/utils/utils.py
+++ b/bcli/utils/utils.py
@@ -1,0 +1,13 @@
+import json
+
+import click
+
+
+def get_store_creds(store: str):
+    """ Get a saved store hash and access token from a store name. """
+    app_dir = click.get_app_dir('bcli')
+    config_path = f'{app_dir}/stores.json'
+
+    with open(config_path, 'r') as stores_file:
+        stores = json.load(stores_file)
+        return stores[store]

--- a/bcli/utils/utils.py
+++ b/bcli/utils/utils.py
@@ -1,13 +1,54 @@
 import json
+from pathlib import Path
 
 import click
 
 
-def get_store_creds(store: str):
-    """ Get a saved store hash and access token from a store name. """
+def read_from_app_dir(file_name: str) -> dict:
+    """ Read JSON data from a file in the bcli app dir. """
     app_dir = click.get_app_dir('bcli')
-    config_path = f'{app_dir}/stores.json'
+    file_path = f'{app_dir}/{file_name}'
 
-    with open(config_path, 'r') as stores_file:
-        stores = json.load(stores_file)
-        return stores[store]
+    if not Path(file_path).is_file():
+        file_data = {}
+    else:
+        with open(file_path, 'r') as file:
+            file_data = json.load(file)
+
+    return file_data
+
+
+def write_to_app_dir(file_name: str, key: str, value: dict) -> dict:
+    """ Write JSON data to a file in the bcli app dir. """
+    app_dir = click.get_app_dir('bcli')
+    file_path = f'{app_dir}/{file_name}'
+
+    if not Path(app_dir).is_dir():
+        Path(app_dir).mkdir(parents=True, exist_ok=True)
+
+    if not Path(file_path).is_file():
+        with open(file_path, 'w') as file:
+            file_data = {key: value}
+            json.dump(file_data, file)
+    else:
+        with open(file_path, 'r') as file:
+            file_data = json.load(file)
+            file_data[key] = value
+        with open(file_path, 'w') as file:
+            json.dump(file_data, file)
+
+    return file_data
+
+
+def delete_from_app_dir(file_name: str, key: str) -> dict:
+    """ Delete a JSON key from a file in the bcli app dir. """
+    app_dir = click.get_app_dir('bcli')
+    file_path = f'{app_dir}/{file_name}'
+
+    with open(file_path, 'r') as file:
+        file_data = json.load(file)
+        file_data.pop(key)
+    with open(file_path, 'w') as file:
+        json.dump(file_data, file)
+
+    return file_data


### PR DESCRIPTION
Closes #2 

Big feature here. Allows bcli users to save their store API credentials in a config file on their local machine.

- Add util functions for reading, writing, and deleting JSON from any file in the bcli app directory. 
- Add `bcli store` command for managing store API credentials 

Unrelated Changes (Ryan forgive me)
- Allow editing any field for `bcli product edit`
- Allow preselecting a field for `bcli product edit`
